### PR TITLE
Use relative paths for file references

### DIFF
--- a/auto-py-to-exe.json
+++ b/auto-py-to-exe.json
@@ -1,89 +1,89 @@
 {
- "version": "auto-py-to-exe-configuration_v1",
- "pyinstallerOptions": [
-  {
-   "optionDest": "noconfirm",
-   "value": true
-  },
-  {
-   "optionDest": "filenames",
-   "value": "E:/Programming/Python/Music-downloader/main.py"
-  },
-  {
-   "optionDest": "onefile",
-   "value": false
-  },
-  {
-   "optionDest": "console",
-   "value": true
-  },
-  {
-   "optionDest": "name",
-   "value": "Music Downloader"
-  },
-  {
-   "optionDest": "contents_directory",
-   "value": "."
-  },
-  {
-   "optionDest": "clean_build",
-   "value": false
-  },
-  {
-   "optionDest": "strip",
-   "value": false
-  },
-  {
-   "optionDest": "noupx",
-   "value": false
-  },
-  {
-   "optionDest": "disable_windowed_traceback",
-   "value": false
-  },
-  {
-   "optionDest": "uac_admin",
-   "value": false
-  },
-  {
-   "optionDest": "uac_uiaccess",
-   "value": false
-  },
-  {
-   "optionDest": "argv_emulation",
-   "value": false
-  },
-  {
-   "optionDest": "bootloader_ignore_signals",
-   "value": false
-  },
-  {
-   "optionDest": "datas",
-   "value": "E:/Programming/Python/Music-downloader/imgs;imgs/"
-  },
-  {
-   "optionDest": "datas",
-   "value": "E:/Programming/Python/Music-downloader/config.py;."
-  },
-  {
-   "optionDest": "datas",
-   "value": "E:/Programming/Python/Music-downloader/downloader.py;."
-  },
-  {
-   "optionDest": "datas",
-   "value": "E:/Programming/Python/Music-downloader/gui.py;."
-  },
-  {
-   "optionDest": "datas",
-   "value": "E:/Programming/Python/Music-downloader/metadata.py;."
-  },
-  {
-   "optionDest": "datas",
-   "value": "E:/Programming/Python/Music-downloader/spotify_client.py;."
+  "version": "auto-py-to-exe-configuration_v1",
+  "pyinstallerOptions": [
+    {
+      "optionDest": "noconfirm",
+      "value": true
+    },
+    {
+      "optionDest": "filenames",
+      "value": "./main.py"
+    },
+    {
+      "optionDest": "onefile",
+      "value": false
+    },
+    {
+      "optionDest": "console",
+      "value": true
+    },
+    {
+      "optionDest": "name",
+      "value": "Music Downloader"
+    },
+    {
+      "optionDest": "contents_directory",
+      "value": "."
+    },
+    {
+      "optionDest": "clean_build",
+      "value": false
+    },
+    {
+      "optionDest": "strip",
+      "value": false
+    },
+    {
+      "optionDest": "noupx",
+      "value": false
+    },
+    {
+      "optionDest": "disable_windowed_traceback",
+      "value": false
+    },
+    {
+      "optionDest": "uac_admin",
+      "value": false
+    },
+    {
+      "optionDest": "uac_uiaccess",
+      "value": false
+    },
+    {
+      "optionDest": "argv_emulation",
+      "value": false
+    },
+    {
+      "optionDest": "bootloader_ignore_signals",
+      "value": false
+    },
+    {
+      "optionDest": "datas",
+      "value": "./imgs;imgs/"
+    },
+    {
+      "optionDest": "datas",
+      "value": "./config.py;."
+    },
+    {
+      "optionDest": "datas",
+      "value": "./downloader.py;."
+    },
+    {
+      "optionDest": "datas",
+      "value": "./gui.py;."
+    },
+    {
+      "optionDest": "datas",
+      "value": "./metadata.py;."
+    },
+    {
+      "optionDest": "datas",
+      "value": "./spotify_client.py;."
+    }
+  ],
+  "nonPyinstallerOptions": {
+    "increaseRecursionLimit": true,
+    "manualArguments": ""
   }
- ],
- "nonPyinstallerOptions": {
-  "increaseRecursionLimit": true,
-  "manualArguments": ""
- }
 }


### PR DESCRIPTION
This pull request updates file paths in the `auto-py-to-exe.json` configuration file to use relative paths instead of absolute paths. This change improves portability, making the project easier to run on different systems.